### PR TITLE
Fixed model-bar offset

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -43,3 +43,7 @@
 #titlebar .dropdown-menu {
     margin-top: -7px;
 }
+
+.modal-bar {
+    top: 27px;
+}


### PR DESCRIPTION
The "Quick Open" modal bar is hidden by the titlebar. 

![hidden modal](https://cloud.githubusercontent.com/assets/18703/3269084/fc9ae668-f2e6-11e3-8436-d44b70a1977f.png)

Small fix. 
