### PR TITLE
Updated z-index value to a large number

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -7,7 +7,7 @@
     left: 0;
     right: 0;
     top: 0;
-    z-index: 50;
+    z-index: 500000;
 }
 
 #titlebar, #titlebar .dropdown-toggle {


### PR DESCRIPTION
When this plugin is used along with other plugins like [brackets-documents-toolbar](https://github.com/dnbard/brackets-documents-toolbar), When a menu item is selected it will be shown on the background [issue](https://github.com/dnbard/brackets-documents-toolbar/issues/39).

Updated the z-index value from 50 to 500000 so that the menu items will be always on top